### PR TITLE
Add parameter "ptimeout"

### DIFF
--- a/src/CodeCoverage.php
+++ b/src/CodeCoverage.php
@@ -26,6 +26,7 @@ class CodeCoverage implements ComposerScriptInterface
 
         $process = new Process($command);
         $process->setTtyByArguments($eventArguments);
+        $process->setProcessTimeoutByArguments($eventArguments);
         $process->run();
 
         return $process->getExitCode();

--- a/src/CodeStyleChecker.php
+++ b/src/CodeStyleChecker.php
@@ -32,6 +32,7 @@ class CodeStyleChecker implements ComposerScriptInterface
 
         $process = new Process($command);
         $process->setTtyByArguments($eventArguments);
+        $process->setProcessTimeoutByArguments($eventArguments);
         $process->run();
 
         $composerIO->write($process->getOutput());

--- a/src/CodeStyleFixer.php
+++ b/src/CodeStyleFixer.php
@@ -27,6 +27,7 @@ class CodeStyleFixer implements ComposerScriptInterface
 
         $process = new Process(self::$command);
         $process->setTtyByArguments($eventArguments);
+        $process->setProcessTimeoutByArguments($eventArguments);
         $process->run();
 
         $composerIO->write($process->getOutput());

--- a/src/MessDetector.php
+++ b/src/MessDetector.php
@@ -26,6 +26,7 @@ class MessDetector implements ComposerScriptInterface
 
         $process = new Process($command);
         $process->setTtyByArguments($eventArguments);
+        $process->setProcessTimeoutByArguments($eventArguments);
         $process->run();
 
         return $process->getExitCode();

--- a/src/Process/Process.php
+++ b/src/Process/Process.php
@@ -17,6 +17,13 @@ class Process extends SymfonyProcess
      */
     const NO_TTY_FLAG = 'notty';
 
+    /**
+     * Flag to set the symfony process timeout as parameter.
+     *
+     * @var string
+     */
+    const PROCESS_TIMEOUT = 'ptimeout';
+
     public function __construct($commandline)
     {
         parent::__construct($commandline);
@@ -25,7 +32,7 @@ class Process extends SymfonyProcess
     /**
      * Check if the process was started with a 'notty' flag, if yes, deactivate it.
      *
-     * @param $eventArguments
+     * @param array $eventArguments
      * @return bool
      */
     public function setTtyByArguments($eventArguments)
@@ -40,6 +47,21 @@ class Process extends SymfonyProcess
             } catch (RuntimeException $e) {
                 return false;
             }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if the process was started with a 'ptimeout' flag, if not, use default 60s timeout
+     *
+     * @param array $eventArguments
+     * @return bool
+     */
+    public function setProcessTimeoutByArguments($eventArguments)
+    {
+        if (self::hasParameterOption(self::PROCESS_TIMEOUT, $eventArguments)) {
+            $this->setTimeout($eventArguments[self::PROCESS_TIMEOUT]);
         }
 
         return true;

--- a/src/SpecificationTest.php
+++ b/src/SpecificationTest.php
@@ -32,6 +32,7 @@ class SpecificationTest implements ComposerScriptInterface
 
         $process = new Process($command);
         $process->setTtyByArguments($eventArguments);
+        $process->setProcessTimeoutByArguments($eventArguments);
         $process->run();
 
         $composerIO->write($process->getOutput());

--- a/tests/specs/Process/ProcessSpec.php
+++ b/tests/specs/Process/ProcessSpec.php
@@ -38,4 +38,11 @@ class ProcessSpec extends ObjectBehavior
             // Testing for `true` or `false` doesn't make sense, so we skip this test.
         }
     }
+
+    function its_process_timeout_can_be_set()
+    {
+        $this->setProcessTimeoutByArguments(array(Process::PROCESS_TIMEOUT => 3600))->shouldReturn(true);
+
+        $this->getTimeout()->shouldReturn((double) 3600);
+    }
 }


### PR DESCRIPTION
The Symfony default process timeout is at 60 seconds.
To avoid killing long running tasks you can specify an timeout in seconds
with the new -ptimeout=3600 flag.