### PR TITLE
Handle PHPCBF exit codes correctly

### DIFF
--- a/src/CodeStyleFixer.php
+++ b/src/CodeStyleFixer.php
@@ -32,12 +32,10 @@ class CodeStyleFixer implements ComposerScriptInterface
 
         $composerIO->write($process->getOutput());
 
-        $exitCode = $process->getExitCode();
-
-        if ($exitCode !== ComposerScriptInterface::EXIT_CODE_OK) {
-            throw new ProcessFailedException($process);
-        }
-
-        return $exitCode;
+        // PHPCBF exit codes:
+        //  0 = Nothing was fixed by PHPCBF.
+        //  1 = PHPCBF fixed all fixable errors.
+        //  2 = PHPCBF fixed some fixable errors, but others failed to fix.
+        return $process->getExitCode();
     }
 }


### PR DESCRIPTION
The previously used code-fixer returned different exit codes.
With PHPCBF, we don't have to handle exit codes at all, since
the result (success, error) is printed on the command line.