### PR TITLE
Use new namespace for code coverage extension

### DIFF
--- a/phpspec-coverage.yml
+++ b/phpspec-coverage.yml
@@ -6,7 +6,7 @@ suites:
     spec_prefix: tests\specs
 
 extensions:
-  LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension:
+  FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension:
     format:
       - html
       - clover


### PR DESCRIPTION
The old one still works, but we should use the new one.